### PR TITLE
ブログ記事詳細ページを作成

### DIFF
--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import Image from 'next/image'
+
+const Article = ({params}:{params:{id: string }}) => {
+
+  return (
+    <div className='max-w-3xl mx-auto p-5'>Article
+        <Image 
+        src ='https://source.unsplash.com/collection/1346951/1000×500?sig=1' alt=''
+        width={1280}
+        height={300}
+        />
+        <h1 className='text-4xl text-center md-10 mt-10'>
+            タイトル
+        </h1>
+        <div className='text-lg leading-relaxed text-justify'>
+            <p>本文</p>
+        </div>
+    </div>
+  )
+}
+
+export default Article

--- a/src/app/blogAPI.ts
+++ b/src/app/blogAPI.ts
@@ -1,4 +1,3 @@
-import { resolve } from "path";
 import {Article} from "./types"
 
 export const getAllArticles = async () : Promise<Article[]> => {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 const  Error = ({reset}:{reset:()=>void}) => {
   // reset もう一度試す を押した時ページがリフレッシュする typescript
   return (
-    <div className='bg-red-100 border-1-4 border-red-500 text-red-700 mt-4 rounded shadow-md mx-auto p-2'>
+    <div className='bg-red-100 border-l-4 border-red-500 text-red-700 mt-4 rounded shadow-md mx-auto p-2'>
       <h3 className='font-bold md-2'>
         エラーが発生しました
       </h3>


### PR DESCRIPTION
**はじめに**
- ブログ記事詳細ページは、blogAPI.tsで取得したAPIのID articles をURL末が表示されている
- next.js13でのルーティングはディレクトリ内のappディレクトリーで行う
***
```page.tsx
import React from 'react'
import Image from 'next/image'

const Article = ({params}:{params:{id: string }}) => {
   console.log(params.id)
  return (
    <div className='max-w-3xl mx-auto p-5'>Article
        <Image 
        src ='https://source.unsplash.com/collection/1346951/1000×500?sig=1' alt=''
        width={1280}
        height={300}
        />
        <h1 className='text-4xl text-center md-10 mt-10'>
            タイトル
        </h1>
        <div className='text-lg leading-relaxed text-justify'>
            <p>本文</p>
        </div>
    </div>
  )
}

export default Article
```
- types.tsで作成した型{id: string }をparamsに格納(ターミナル上で確認できる)
- 画像はArticleList.tsxで実装した<Image>
- #9 