### PR TITLE
ISRでブログ詳細取得用APIを作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "json-server":"json-server src/app/data/posts.json --port 3003"
+    "json-server": "json-server src/app/data/posts.json --port 3003"
   },
   "dependencies": {
     "json-server": "^1.0.0-alpha.21",

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -1,23 +1,28 @@
-import React from 'react'
-import Image from 'next/image'
+import React from "react";
+import Image from "next/image";
+import { getDetailArticle } from "@/app/blogAPI";
 
-const Article = ({params}:{params:{id: string }}) => {
-    console.log(params.id)
+const Article = async ({ params }: { params: { id: string } }) => {
+  // console.log(params.id)
+  const detailArticle = await getDetailArticle(params.id);
+  console.log(detailArticle);
+  //
+
   return (
-    <div className='max-w-3xl mx-auto p-5'>Article
-        <Image 
-        src ='https://source.unsplash.com/collection/1346951/1000×500?sig=1' alt=''
+    <div className="max-w-3xl mx-auto p-5">
+      Article
+      <Image
+        src="https://source.unsplash.com/collection/1346951/1000×500?sig=1"
+        alt=""
         width={1280}
         height={300}
-        />
-        <h1 className='text-4xl text-center md-10 mt-10'>
-            タイトル
-        </h1>
-        <div className='text-lg leading-relaxed text-justify'>
-            <p>本文</p>
-        </div>
+      />
+      <h1 className="text-4xl text-center md-10 mt-10">タイトル</h1>
+      <div className="text-lg leading-relaxed text-justify">
+        <p>本文</p>
+      </div>
     </div>
-  )
-}
+  );
+};
 
-export default Article
+export default Article;

--- a/src/app/blogAPI.ts
+++ b/src/app/blogAPI.ts
@@ -1,16 +1,51 @@
-import {Article} from "./types"
+import { notFound } from "next/navigation";
+import { Article } from "./types";
 
-export const getAllArticles = async () : Promise<Article[]> => {
-    const res = await fetch(`http://localhost:3003/posts`,{
-        cache:'no-store'});//SSR='no-store' SSG='force-cache'
-        
-        if(!res.ok){
-            throw new Error("エラーが発生しました");
-        }
-        await new Promise((resolve) => setTimeout(resolve,1500));
+//page.tsx(ルートディレクトリ)の記事一覧を表示させるためのAPI取得
+export const getAllArticles = async (): Promise<Article[]> => {
+  /*<Article[]>
+  →複数の記事を配列で取り込むため[]をつける*/
+  const res = await fetch(`http://localhost:3003/posts`, {
+    cache: "no-store",
+  }); //SSR='no-store' SSG='force-cache'
+  console.log(res);
 
+  if (!res.ok) {
+    throw new Error("エラーが発生しました");
+  }
+  await new Promise((resolve) => setTimeout(resolve, 1500));
 
-        const articles  = await res.json();
-        //resという変数は文字列もしくはオブジェクトで存在しているためJSON形式にシリアライズ(文字列化)する必要がある
-        return articles;
+  const articles = await res.json();
+  //resという変数は文字列もしくはオブジェクトで存在しているためJSON形式にシリアライズ(文字列化)する必要がある
+  return articles;
+};
+
+//各記事ページごとに内容を反映させるためのAPI取得をISR(再生成)で行う
+export const getDetailArticle = async (id: string): Promise<Article> => {
+  /*<Article[]>
+  →一つの記事の詳細(単数)を取り込むので配列[]はつけない*/
+  const res = await fetch(`http://localhost:3003/posts/${id}`, {
+    //どの記事を見るのかを指定する必要があるために↑の引数はid:stringを取得させる
+    /*fetch(`http://localhost:3003/posts/${id}`,
+    → posts.jsonで記述した記事の詳細を開くためには同じくposts.jsonで記述したid(ウェブのURL文末になる)をfetch関数で書かないといけない*/
+    next: { revalidate: 60 }, //ISR 60=1分　3600=1時間　新しい内容に編集して更新されたとき最初のサーバーからの取得はSSRだが、その後の取得がSSGで読み込みが早い
+  });
+
+  if (res.status === 404) {
+    notFound();
+  }
+  /*もしresで指示したAPI操作のリクエストが通らない、もしくはサーバーに問題があった場合など指定したページが存在しないときに表示されるステータスコード
+  next.js側で用意されているnotFound()関数をimportすることで、404ページを用意した際にページ遷移されるようになる*/
+
+  if (!res.ok) {
+    throw new Error("エラーが発生しました");
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  //ページ表示までの遅延指定、複数記事をルートディレクトリに表示させる際にしたものと同じ 今回は1秒
+
+  const article = await res.json();
+  //resという変数は文字列もしくはオブジェクトで存在しているためJSON形式にシリアライズ(文字列化)する必要がある
+  return article;
+  //  →一つの記事の詳細(単数)を取り込むので単数形に書き換えた
 };


### PR DESCRIPTION
**各記事ページごとに内容を反映させるためのAPI取得をISR(再生成)で行う**

```blogAPI.ts
export const getDetailArticle = async (id: string): Promise<Article> => {
```
- <Article[]> 一つの記事の詳細(単数)を取り込むので配列[]はつけない
- どの記事を見るのかを指定する必要があるため引数には(id:string)を取得させる

```blogAPI.ts
  const res = await fetch(`http://localhost:3003/posts/${id}`, {
      next: { revalidate: 60 }, //ISR 60=1分　3600=1時間　新しい内容に編集して更新されたとき最初のサーバーからの取得はSSRだが、その後の取得がSSGで読み込みが早い
  });
```
- `fetch(http://localhost:3003/posts/${id},`
    → posts.jsonで記述した記事の詳細を開くためには同じくposts.jsonで記述したid(ウェブのURL文末になる)をfetch関数で書かないといけない

```blogAPI.ts
  if (res.status === 404) {
    notFound();
  }
```
 - もしresで指示したAPI操作のリクエストが通らない、もしくはサーバーに問題があった場合など指定したページが存在しないときに表示されるステータスコード
  next.js側で用意されているnotFound()関数をimportすることで、404ページを用意した際にページ遷移されるようになる

```blogAPI.ts
  if (!res.ok) {
    throw new Error("エラーが発生しました");
  }

  await new Promise((resolve) => setTimeout(resolve, 1000));
```
- ページ表示までの遅延指定、複数記事をルートディレクトリに表示させる際にしたものと同じ 今回は1秒

```blogAPI.ts
  const article = await res.json();
  //resという変数は文字列もしくはオブジェクトで存在しているためJSON形式にシリアライズ(文字列化)する必要がある
  return article;
};

``` 
-  ` article`→一つの記事の詳細(単数)を取り込むので単数形に書き換えた

#10 