### PR TITLE
404notFoundページを作成

### DIFF
--- a/src/app/articles/not-found.tsx
+++ b/src/app/articles/not-found.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+const notFound = () => {
+  return (
+    <div className="flex items-center justify-center mt-20">
+      <div className="p-8 rounded-lg shadow-md text-center bg-white">
+        <h1 className="text-2xl font-bold mb-4 text-gray-800">404</h1>
+        <p className="text-gray-600">ページが見つかりませんでした。</p>
+      </div>
+    </div>
+    //articlesファイルの配下にのみ作成したnotfoundページなのでURLの/articles/---でエラーが起きた時のみこのエラーページは表示される
+  );
+};
+
+export default notFound;


### PR DESCRIPTION
**URLの/articles/---でエラーが起きた時のエラーページ実装**
app
  |--articles ←ここの配下
  |--compornents
  |--data

not-found.tsx
```not-found.tsx
import React from "react";

const notFound = () => {
  return (
    <div className="flex items-center justify-center mt-20">
      <div className="p-8 rounded-lg shadow-md text-center bg-white">
        <h1 className="text-2xl font-bold mb-4 text-gray-800">404</h1>
        <p className="text-gray-600">ページが見つかりませんでした。</p>
      </div>
    </div>
  );
};

export default notFound;
``` 
- articlesファイルの配下にのみ作成したnotfoundページなのでURLの/articles/---でエラーが起きた時のみこのエラーページは表示される
#14 